### PR TITLE
Multiple selections where some ends in FirstOrDefault() does not throw ex

### DIFF
--- a/net7.0/Telia.LinqToGraphQLToModel.Benchmarks/Telia.LinqToGraphQLToModel.Benchmarks.csproj
+++ b/net7.0/Telia.LinqToGraphQLToModel.Benchmarks/Telia.LinqToGraphQLToModel.Benchmarks.csproj
@@ -14,9 +14,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.13.4" />
-		<PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.4" />
-		<PackageReference Include="SystemLibrary.Common.Net" Version="6.11.0.1" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+		<PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.12" />
+		<PackageReference Include="SystemLibrary.Common.Net" Version="7.6.0.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/net7.0/Telia.LinqToGraphQLToModel.Tests/GraphqlResponseToModels/Assets/multiple-selections-with-null-and-errors.txt
+++ b/net7.0/Telia.LinqToGraphQLToModel.Tests/GraphqlResponseToModels/Assets/multiple-selections-with-null-and-errors.txt
@@ -1,0 +1,70 @@
+﻿{
+    "data": {
+        "field0": {
+            "field0": null,
+            "field1": {
+                "field0": [],
+                "__typename": "CallPricesCollection"
+            },
+            "field2": {
+                "field0": "PRIVATE",
+                "__typename": "AccountData"
+            },
+            "field3": null,
+            "__typename": "SubscriptionData"
+        },
+        "field1": {
+            "field0": [
+                {
+                    "countryCode": "DNK",
+                    "productOfferingDescription": "A",
+                    "smsPrice": 1.5,
+                    "mmsPrice": 11,
+                    "__typename": "CallPrices"
+                },
+                {
+                    "countryCode": "DNK",
+                    "productOfferingDescription": "B",
+                    "smsPrice": 1.5,
+                    "mmsPrice": 10,
+                    "__typename": "CallPrices"
+                },
+                {
+                    "countryCode": "DNK",
+                    "productOfferingDescription": "C",
+                    "smsPrice": 1.5,
+                    "mmsPrice": 12,
+                    "__typename": "CallPrices"
+                }
+            ],
+            "__typename": "CallPricesCollection"
+        },
+        "__typename": "Query"
+    },
+    "errors": [
+        {
+            "message": "INVALID_ARGUMENT1: A long error with json inside string: a4c74e95-b386-4803-a137-a0c7015fe91c | [{\"@type\":\"type.test.com\", \"errorMessage\":\"INVALID_DATA\"}]",
+            "errorType": "REMOTE",
+            "data": null,
+            "errorInfo": null,
+            "locations": [
+                {
+                    "line": 1,
+                    "column": 1,
+                }
+            ]
+        },
+           {
+            "message": "INVALID_ARGUMENT2: A long error with json inside string: a4c74e95-b386-4803-a137-a0c7015fe91c | [{\"@type\":\"type.test.com\", \"errorMessage\":\"INVALID_DATA\"}]",
+            "errorType": "REMOTE",
+            "data": null,
+            "errorInfo": null,
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 2,
+                }
+            ]
+        }
+    ]
+}

--- a/net7.0/Telia.LinqToGraphQLToModel.Tests/GraphqlResponseToModels/Queries/CallPricesQueries.cs
+++ b/net7.0/Telia.LinqToGraphQLToModel.Tests/GraphqlResponseToModels/Queries/CallPricesQueries.cs
@@ -1,0 +1,33 @@
+﻿using SystemLibrary.Common.Net;
+
+using Telia.LinqToGraphQLToModel.Tests.LinqToGraphql.Schema;
+
+namespace Telia.LinqToGraphQLToModel.Tests.GraphqlResponseToModels.Queries;
+
+public class CallPricesQueries : GraphQLQuery<CallPricesSchema>
+{
+    string GetMultipleWithNullAndErrors(string graphql)
+    {
+        return Assemblies.GetEmbeddedResource("GraphqlResponseToModels/Assets", "multiple-selections-with-null-and-errors.txt");
+    }
+
+    public CallPricesModel GetCallPricesModel()
+    {
+        var countryCode = "DK";
+        var countryFilter = new CountryFilter() { CountryCode = countryCode };
+        var callPricesFilter = new CallPricesFilter { CountryCode = countryCode };
+
+        var msisdn = "12344555";
+
+        return Query(q => new CallPricesModel
+        {
+            OfferingPriceDetails = q.SubscriptionData(msisdn).UserOffering().OfferingPrices.Select(e => e.OfferingPrices()).FirstOrDefault(),
+            CallPrices = q.SubscriptionData(msisdn).CallPricesCollection(callPricesFilter).CallPrices,
+            OtherCallPrices = q.CallPricesCollection(callPricesFilter).CallPrices,
+            AgreementType = q.SubscriptionData(msisdn).Account.AgreementType,
+            Code = q.SubscriptionData(msisdn).UserOffering().PricePlan,
+
+        }, GetMultipleWithNullAndErrors);
+    }
+
+}

--- a/net7.0/Telia.LinqToGraphQLToModel.Tests/GraphqlResponseToModels/Tests/CallPricesResponseTests.cs
+++ b/net7.0/Telia.LinqToGraphQLToModel.Tests/GraphqlResponseToModels/Tests/CallPricesResponseTests.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using SystemLibrary.Common.Net.Extensions;
+
+using Telia.LinqToGraphQLToModel.Tests._Abstract;
+using Telia.LinqToGraphQLToModel.Tests.GraphqlResponseToModels.Queries;
+
+namespace Telia.LinqToGraphQLToModel.Tests.GraphqlResponseToModels.Tests;
+
+[TestClass]
+public class CallPricesResponseTests : BaseTestClass
+{
+    [TestMethod]
+    public void MultiWithNullAndErrors()
+    {
+        var queries = new CallPricesQueries();
+
+        var callPriceModel = queries.GetCallPricesModel();
+
+        Assert.IsTrue(callPriceModel != null);
+
+        Assert.IsTrue(callPriceModel.OfferingPriceDetails.IsNot());
+        Assert.IsTrue(callPriceModel.CallPrices.IsNot());
+
+        Assert.IsTrue(callPriceModel.OtherCallPrices.First().MmsPrice > 0);
+    }
+}

--- a/net7.0/Telia.LinqToGraphQLToModel.Tests/LinqToGraphql/Schema/CallPricesSchema.cs
+++ b/net7.0/Telia.LinqToGraphQLToModel.Tests/LinqToGraphql/Schema/CallPricesSchema.cs
@@ -1,0 +1,143 @@
+﻿using Telia.LinqToGraphQLToModel.Schema.Attributes;
+using Telia.LinqToGraphQLToModel.Tests.GraphqlResponseToModels.Schema;
+
+namespace Telia.LinqToGraphQLToModel.Tests.LinqToGraphql.Schema;
+
+[GraphQLType("Query")]
+public class CallPricesSchema
+{
+    [GraphQLField("callPricesCollection", "CallPricesCollection")]
+    public virtual CallPricesCollection CallPricesCollection([GraphQLArgumentAttribute("filter", "CallPricesFilter")] CallPricesFilter filter)
+    {
+        throw new InvalidOperationException();
+    }
+
+    [GraphQLField("callPrices", "[CallPrices]")]
+    public virtual IEnumerable<CallPrices> CallPrices { get; set; }
+
+
+    [GraphQLFieldAttribute("subscriptionData", "SubscriptionData!")]
+    public virtual SubscriptionData SubscriptionData([GraphQLArgumentAttribute("phoneNumber", "String")] String phoneNumber)
+    {
+        throw new InvalidOperationException();
+    }
+
+    [GraphQLFieldAttribute("internationalPrices", "[CallPrices]")]
+    public virtual IEnumerable<CallPrices> InternationalPrices { get; set; }
+}
+
+public class CallPricesModel
+{
+    public IEnumerable<OfferingPriceDetails> OfferingPriceDetails { get; set; }
+    public IEnumerable<CallPrices> CallPrices { get; set; }
+    public IEnumerable<CallPrices> OtherCallPrices { get; set; }
+    public AgreementType AgreementType { get; set; }
+    public string Code { get; set; }
+}
+
+[GraphQLTypeAttribute("CallPrices")]
+public class CallPrices
+{
+    [GraphQLFieldAttribute("countryCode", "String")]
+    public virtual String CountryCode { get; set; }
+
+    [GraphQLFieldAttribute("smsPrice", "Float")]
+    public virtual Single? SmsPrice { get; set; }
+
+    [GraphQLFieldAttribute("mmsPrice", "Float")]
+    public virtual Single? MmsPrice { get; set; }
+
+    [GraphQLFieldAttribute("productOfferingDescription", "String")]
+    public virtual String ProductOfferingDescription { get; set; }
+}
+
+
+[GraphQLType("CountryCollection")]
+public class CallPricesCollection
+{
+    [GraphQLField("callPrices", "[CallPrices]")]
+    public virtual IEnumerable<CallPrices> CallPrices { get; set; }
+}
+
+[GraphQLTypeAttribute("CallPricesFilter")]
+public class CallPricesFilter
+{
+    [GraphQLFieldAttribute("countryCode", "String")]
+    public virtual String CountryCode { get; set; }
+
+    [GraphQLFieldAttribute("priceplan", "String")]
+    public virtual String Priceplan { get; set; }
+}
+
+
+[GraphQLTypeAttribute("SubscriptionData")]
+public class SubscriptionData
+{
+    [GraphQLFieldAttribute("subscriptionType", "String")]
+    public virtual String SubscriptionType { get; set; }
+
+    [GraphQLFieldAttribute("account", "AccountData!")]
+    public virtual AccountData Account { get; set; }
+
+    [GraphQLFieldAttribute("invoiceType", "String!")]
+    public virtual String InvoiceType { get; set; }
+
+    [GraphQLFieldAttribute("agreementType", "AgreementType")]
+    public virtual AgreementType? AgreementType { get; set; }
+    
+    [GraphQLFieldAttribute("callPricesCollection", "CallPricesCollection")]
+    public virtual CallPricesCollection CallPricesCollection()
+    {
+        throw new InvalidOperationException();
+    }
+
+    [GraphQLFieldAttribute("callPricesCollection", "CallPricesCollection")]
+    public virtual CallPricesCollection CallPricesCollection([GraphQLArgumentAttribute("filter", "CallPricesFilter")] CallPricesFilter filter)
+    {
+        throw new InvalidOperationException();
+    }
+
+    [GraphQLFieldAttribute("userOffering", "UserOffering")]
+    public virtual UserOffering UserOffering()
+    {
+        throw new InvalidOperationException();
+    }
+}
+
+
+[GraphQLTypeAttribute("UserOffering")]
+public class UserOffering
+{
+    [GraphQLFieldAttribute("pricePlan", "String")]
+    public virtual String PricePlan { get; set; }
+
+    [GraphQLFieldAttribute("name", "String")]
+    public virtual String Name { get; set; }
+
+    [GraphQLFieldAttribute("offeringPrices", "[OfferingPrice]")]
+    public virtual IEnumerable<OfferingPrice> OfferingPrices { get; set; }
+
+}
+
+
+[GraphQLTypeAttribute("OfferingPrice")]
+public class OfferingPrice
+{
+    [GraphQLFieldAttribute("offeringPrices", "[OfferingPriceDetails]")]
+    public virtual IEnumerable<OfferingPriceDetails> OfferingPrices()
+    {
+        throw new InvalidOperationException();
+    }
+}
+
+
+
+[GraphQLTypeAttribute("OfferingPriceDetails")]
+public class OfferingPriceDetails
+{
+    [GraphQLFieldAttribute("code", "String")]
+    public virtual String Code { get; set; }
+
+    [GraphQLFieldAttribute("amount", "Float")]
+    public virtual Single? Amount { get; set; }
+}

--- a/net7.0/Telia.LinqToGraphQLToModel.Tests/Telia.LinqToGraphQLToModel.Tests.csproj
+++ b/net7.0/Telia.LinqToGraphQLToModel.Tests/Telia.LinqToGraphQLToModel.Tests.csproj
@@ -16,6 +16,7 @@
 	<ItemGroup>
 		<None Remove="GraphqlResponseToModels\Assets\countries-response.txt" />
 		<None Remove="GraphqlResponseToModels\Assets\country-collection-with-countries-response.txt" />
+		<None Remove="GraphqlResponseToModels\Assets\multiple-selections-with-null-and-errors.txt" />
 		<None Remove="LinqToGraphql\Assets\Mutate_Country_Returns_Id.txt" />
 		<None Remove="LinqToGraphql\Assets\Query_Select_Enum_Custom_Serialization.txt" />
 		<None Remove="LinqToGraphql\Assets\Query_Select_Enum_Default_Serialization.txt" />
@@ -23,6 +24,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<EmbeddedResource Include="GraphqlResponseToModels\Assets\multiple-selections-with-null-and-errors.txt" />
 		<EmbeddedResource Include="LinqToGraphql\Assets\Query_Select_Enum_Default_Serialization.txt" />
 		<EmbeddedResource Include="LinqToGraphql\Assets\Query_Select_Enum_Custom_Serialization.txt" />
 	</ItemGroup>
@@ -50,9 +52,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
 		<PackageReference Include="coverlet.collector" Version="3.2.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/net7.0/Telia.LinqToGraphQLToModel/GraphQLQuery.cs
+++ b/net7.0/Telia.LinqToGraphQLToModel/GraphQLQuery.cs
@@ -122,6 +122,7 @@ public class GraphQLQuery<TQueryRoot>
 
         var query = printer.Print(operationDefinition);
 
+ 
         var temp = new GraphQLQueryData(query, variableValues);
 
         string graphqlQuery;
@@ -151,8 +152,12 @@ public class GraphQLQuery<TQueryRoot>
         var response = onSendGraphQl(graphqlQuery);
 
         if (response.IsNot()) return default;
-        
-        var graphQlResponse = JsonConvert.DeserializeObject<GraphQLResponse>(response);
+
+        var graphQlResponse = JsonConvert.DeserializeObject<GraphQLResponse>(response, new JsonSerializerSettings()
+        {
+            DefaultValueHandling = DefaultValueHandling.Ignore,
+            MissingMemberHandling = MissingMemberHandling.Ignore,
+        });
 
         if (graphQlResponse?.Data == null) return default;
 

--- a/net7.0/Telia.LinqToGraphQLToModel/QueryContext.cs
+++ b/net7.0/Telia.LinqToGraphQLToModel/QueryContext.cs
@@ -77,7 +77,9 @@ internal class QueryContext
 
     internal bool ContainsBinding(Expression node)
     {
-        return this.bindings.ContainsKey(node);
+        if (node == null) return false;
+
+        return this.bindings?.ContainsKey(node) == true;
     }
 
     internal void AddModelToParameterBinding(ParameterExpression parameterExpression, JToken response)

--- a/net7.0/Telia.LinqToGraphQLToModel/Telia.LinqToGraphQLToModel.csproj
+++ b/net7.0/Telia.LinqToGraphQLToModel/Telia.LinqToGraphQLToModel.csproj
@@ -13,9 +13,9 @@
 	
 	<ItemGroup>
 		<PackageReference Include="GraphQL-Parser" Version="8.1.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-		<PackageReference Include="System.Text.Json" Version="6.0.7" />
-		<PackageReference Include="SystemLibrary.Common.Net" Version="6.11.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="System.Text.Json" Version="7.0.4" />
+		<PackageReference Include="SystemLibrary.Common.Net" Version="7.6.0.4" />
 	</ItemGroup>
 	
 	<ItemGroup>


### PR DESCRIPTION
- null ex fixed for selections ending with FirstOrDefault, where IEnumerable would be null from the response

- added a test to cover it, including a query schema, model and a response model

- update nuget dependencies to their highest patch on .NET 7
