### PR TITLE
Fix `JsonSerializer.DeserializeAsyncEnumerable` method against an untrusted input using System.Text.Json may result in Denial of Service

### DIFF
--- a/net7.0/Telia.LinqToGraphQLToModel/Telia.LinqToGraphQLToModel.csproj
+++ b/net7.0/Telia.LinqToGraphQLToModel/Telia.LinqToGraphQLToModel.csproj
@@ -14,7 +14,7 @@
 	<ItemGroup>
 		<PackageReference Include="GraphQL-Parser" Version="8.1.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="System.Text.Json" Version="7.0.4" />
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 		<PackageReference Include="SystemLibrary.Common.Net" Version="7.6.0.4" />
 	</ItemGroup>
 	


### PR DESCRIPTION
A vulnerability exists in [.graphql-typed-client](https://github.com/telia-oss/graphql-typed-client) when calling the JsonSerializer.DeserializeAsyncEnumerable method against an untrusted input using System.Text.Json may result in Denial of Service.

[CWE-400](https://cwe.mitre.org/data/definitions/400.html)
[CVE-2024-30105](https://nvd.nist.gov/vuln/detail/CVE-2024-30105)
